### PR TITLE
fix: properly mute when override money loot sound

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -86,6 +86,17 @@ function RLF:PLAYER_ENTERING_WORLD(event, isLogin, isReload)
 		end
 	end
 	G_RLF.AuctionIntegrations:Init()
+	if G_RLF.db.global.money.overrideMoneyLootSound then
+		MuteSoundFile(G_RLF.GameSounds.LOOT_SMALL_COIN)
+		if G_RLF.db.global.money.moneyLootSound ~= "" then
+			UnmuteSoundFile(G_RLF.db.global.money.moneyLootSound)
+		end
+	else
+		if G_RLF.db.global.money.moneyLootSound == "" then
+			MuteSoundFile(G_RLF.db.global.money.moneyLootSound)
+		end
+		UnmuteSoundFile(G_RLF.GameSounds.LOOT_SMALL_COIN)
+	end
 end
 
 local optionsFrame

--- a/config/Features/MoneyConfig.lua
+++ b/config/Features/MoneyConfig.lua
@@ -169,7 +169,7 @@ G_RLF.options.args.features.args.moneyConfig = {
 
 function MoneyConfig:OverrideSound()
 	if G_RLF.db.global.money.overrideMoneyLootSound then
-		MuteSoundFile(120)
+		MuteSoundFile(G_RLF.GameSounds.LOOT_SMALL_COIN)
 		if G_RLF.db.global.money.moneyLootSound ~= "" then
 			UnmuteSoundFile(G_RLF.db.global.money.moneyLootSound)
 		end
@@ -177,7 +177,7 @@ function MoneyConfig:OverrideSound()
 		if G_RLF.db.global.money.moneyLootSound == "" then
 			MuteSoundFile(G_RLF.db.global.money.moneyLootSound)
 		end
-		UnmuteSoundFile(120)
+		UnmuteSoundFile(G_RLF.GameSounds.LOOT_SMALL_COIN)
 	end
 end
 

--- a/spec/common_stubs.lua
+++ b/spec/common_stubs.lua
@@ -266,6 +266,9 @@ function common_stubs.setup_G_RLF(spy)
 			ANGLE = 5,
 			BAR = 6,
 		},
+		GameSounds = {
+			LOOT_SMALL_COIN = 567428,
+		},
 		IsRetail = spy.new(function()
 			return true
 		end),
@@ -456,6 +459,9 @@ function common_stubs.stub_WoWGlobals(spy)
 	_G.GetLocale = function()
 		return "enUS"
 	end
+
+	_G.MuteSoundFile = function() end
+	_G.UnmuteSoundFile = function() end
 end
 
 function common_stubs.stub_C_CurrencyInfo()

--- a/utils/Enums.lua
+++ b/utils/Enums.lua
@@ -88,3 +88,7 @@ G_RLF.WrapCharEnum = {
 	ANGLE = 5,
 	BAR = 6,
 }
+
+G_RLF.GameSounds = {
+	LOOT_SMALL_COIN = 567428,
+}


### PR DESCRIPTION
Closes #271 