### PR TITLE
fix: extend extra equipment text to show 

### DIFF
--- a/RPGLootFeed/utils/ItemInfo.lua
+++ b/RPGLootFeed/utils/ItemInfo.lua
@@ -379,7 +379,7 @@ function ItemInfo:GetEquipmentTypeText()
 
 	local alwaysShowSubTypes = { Cloth = true, Leather = true, Mail = true, Plate = true }
 	local equipLocShowSubType = { INVTYPE_WEAPONMAINHAND = true, INVTYPE_WEAPONOFFHAND = true }
-	local equipLocShowOnlySubType = { INVTYPE_WEAPON = true, INVTYPE_2HWEAPON = true }
+	local equipLocShowOnlySubType = { INVTYPE_WEAPON = true, INVTYPE_2HWEAPON = true, INVTYPE_SHIELD = true, INVTYPE_RANGEDRIGHT = true }
 
 	local equipmentTypeText = ""
 	if self.itemSubType and alwaysShowSubTypes[self.itemSubType] then

--- a/RPGLootFeed/utils/ItemInfo.lua
+++ b/RPGLootFeed/utils/ItemInfo.lua
@@ -379,7 +379,13 @@ function ItemInfo:GetEquipmentTypeText()
 
 	local alwaysShowSubTypes = { Cloth = true, Leather = true, Mail = true, Plate = true }
 	local equipLocShowSubType = { INVTYPE_WEAPONMAINHAND = true, INVTYPE_WEAPONOFFHAND = true }
-	local equipLocShowOnlySubType = { INVTYPE_WEAPON = true, INVTYPE_2HWEAPON = true, INVTYPE_SHIELD = true, INVTYPE_RANGEDRIGHT = true }
+	local equipLocShowOnlySubType = {
+		INVTYPE_WEAPON = true,
+		INVTYPE_2HWEAPON = true,
+		INVTYPE_SHIELD = true,
+		INVTYPE_RANGEDRIGHT = true,
+		INVTYPE_RANGED = true,
+	}
 
 	local equipmentTypeText = ""
 	if self.itemSubType and alwaysShowSubTypes[self.itemSubType] then


### PR DESCRIPTION
Extend extra equipment text to show:
- "guns" "bows" instead of "ranged"
- "shields" instead of "off-hands"

<img width="415" height="210" alt="image" src="https://github.com/user-attachments/assets/3be5b48b-3d4f-475e-8f70-f3bf9e40fc20" />


based on https://warcraft.wiki.gg/wiki/Enum.InventoryType