### PR TITLE
fix: secondary text row for right-aligned loot feed

### DIFF
--- a/.github/prompts/mwa.implement.prompt.md
+++ b/.github/prompts/mwa.implement.prompt.md
@@ -1,5 +1,5 @@
 ---
-name: implement
+name: mwa.implement
 description: Implement a feature from a GitHub issue with plan integration
 argument-hint: Issue number (e.g., #123)
 agent: agent

--- a/.github/prompts/mwa.park.prompt.md
+++ b/.github/prompts/mwa.park.prompt.md
@@ -1,5 +1,5 @@
 ---
-name: park
+name: mwa.park
 description: Save session progress and generate handoff summary for context transfer
 agent: agent
 tools: ["vscode", "read", "edit", "search", "todo"]

--- a/.github/prompts/mwa.plan.prompt.md
+++ b/.github/prompts/mwa.plan.prompt.md
@@ -1,5 +1,5 @@
 ---
-name: plan
+name: mwa.plan
 description: Plan a feature from a GitHub issue with technical design and implementation roadmap
 argument-hint: Issue number (e.g., #123)
 agent: agent

--- a/.github/prompts/mwa.refactor.prompt.md
+++ b/.github/prompts/mwa.refactor.prompt.md
@@ -1,6 +1,6 @@
 ---
-name: refactor
-description: Plan and execute complex multi-file refactoring using GPT-5.1-Codex-Max subagent
+name: mwa.refactor
+description: Plan and execute complex multi-file refactoring using GPT-5.4 subagent
 argument-hint: Brief description of refactoring goal
 agent: agent
 tools: ["vscode", "execute", "read", "agent", "edit", "search", "todo"]
@@ -8,18 +8,18 @@ tools: ["vscode", "execute", "read", "agent", "edit", "search", "todo"]
 
 # Refactor - Complex Code Restructuring
 
-You are orchestrating a complex refactoring session. Your role is to **plan, delegate to GPT-5.1-Codex-Max, validate, and recover** if needed. **Never perform large-scale or multi-file refactoring directly** - always delegate the actual code changes to GPT-5.1-Codex-Max via the `runSubagent` tool.
+You are orchestrating a complex refactoring session. Your role is to **plan, delegate to GPT-5.4, validate, and recover** if needed. **Never perform large-scale or multi-file refactoring directly** - always delegate the actual code changes to GPT-5.4 via the `runSubagent` tool.
 
-## Why GPT-5.1-Codex-Max for Refactoring?
+## Why GPT-5.4 for Refactoring?
 
-**Strengths of GPT-5.1-Codex-Max**:
+**Strengths of GPT-5.4**:
 
 - Superior accuracy for multi-line and multi-file code changes
 - Better at preserving exact whitespace, indentation, and code structure
 - More reliable with complex find-and-replace operations across many files
 - Stronger at maintaining consistency when updating multiple call sites
 
-**Your Role as Orchestrator (Claude Sonnet 4.5)**:
+**Your Role as Orchestrator (Claude Haiku 4.5)**:
 
 - High-level planning and validation
 - Pre-flight checks and safety analysis
@@ -31,7 +31,7 @@ You are orchestrating a complex refactoring session. Your role is to **plan, del
 
 ## GOLDEN RULES
 
-1. **NEVER perform the refactoring yourself** - Always use `runSubagent` with GPT-5.1-Codex-Max
+1. **NEVER perform the refactoring yourself** - Always use `runSubagent` with GPT-5.4
 2. **Create git checkpoint** before starting (remind user to commit current state)
 3. **Break large refactors** into smaller, independently validatable steps
 4. **Validate after each step** before proceeding to the next
@@ -108,14 +108,14 @@ Proceed with this plan?
 
 **Wait for user approval** before continuing.
 
-### Step 4: Execute via GPT-5.1-Codex-Max Subagent
+### Step 4: Execute via GPT-5.4 Subagent
 
-**For each step in the plan**, delegate to GPT-5.1-Codex-Max:
+**For each step in the plan**, delegate to GPT-5.4:
 
 ```markdown
 Use the `runSubagent` tool with this prompt:
 
-You are GPT-5.1-Codex-Max performing a precise code refactoring for RPGLootFeed.
+You are GPT-5.4 performing a precise code refactoring for RPGLootFeed.
 
 ## Context
 
@@ -381,7 +381,7 @@ Please proceed with this refactoring step.
 
 ### Do:
 
-- ✅ Always delegate actual refactoring to GPT-5.1-Codex-Max
+- ✅ Always delegate actual refactoring to GPT-5.4
 - ✅ Break large refactors into 3-5 validatable steps
 - ✅ Use git checkpoints between major steps
 - ✅ Validate syntax and build after every step
@@ -463,7 +463,7 @@ If refactoring changes user-visible features:
 2. Analyze current currency code locations
 3. Ask user to create git checkpoint
 4. Present plan: Create Utils/Currency.lua, extract functions, update call sites, update TOC
-5. For each step, use `runSubagent` with GPT-5.1-Codex-Max
+5. For each step, use `runSubagent` with GPT-5.4
 6. Validate after each step (syntax, build, TOC check)
 7. Final validation and recommend in-game testing
 8. Provide rollback instructions
@@ -474,7 +474,7 @@ If refactoring changes user-visible features:
 
 **Be transparent** about the process:
 
-- "I'm delegating this refactoring to GPT-5.1-Codex-Max for accuracy"
+- "I'm delegating this refactoring to GPT-5.4 for accuracy"
 - "Validating changes before proceeding to next step"
 - "This is a complex refactor - I've broken it into N steps for safety"
 

--- a/.github/prompts/mwa.resume.prompt.md
+++ b/.github/prompts/mwa.resume.prompt.md
@@ -1,5 +1,5 @@
 ---
-name: resume
+name: mwa.resume
 description: Restore context from parked session and continue work seamlessly
 argument-hint: Paste handoff summary from /park
 agent: agent

--- a/.github/prompts/mwa.review.prompt.md
+++ b/.github/prompts/mwa.review.prompt.md
@@ -1,5 +1,5 @@
 ---
-name: review
+name: mwa.review
 description: Perform code review from perspective of seasoned WoW addon developer
 argument-hint: Optional: file path or feature area to review
 agent: agent

--- a/RPGLootFeed/LootDisplay/LootDisplayFrame/LootDisplayRow/RowTextMixin.lua
+++ b/RPGLootFeed/LootDisplay/LootDisplayFrame/LootDisplayRow/RowTextMixin.lua
@@ -429,8 +429,16 @@ function RLF_RowTextMixin:RecheckSecondaryCoinDisplayAnchor()
 	elseif self.CoinDisplay and self.CoinDisplay:IsShown() then
 		anchorFrame = self.CoinDisplay
 	end
+	-- Anchor direction depends on where the icon sits.  When the icon is on the
+	-- right (RIGHT alignment), the coin display must appear to the LEFT of the
+	-- last text element so it doesn't collide with the icon.
+	local iconOnLeft = self.cachedRowTextAlignment ~= G_RLF.TextAlignment.RIGHT
 	self.SecondaryCoinDisplay:ClearAllPoints()
-	self.SecondaryCoinDisplay:SetPoint("LEFT", anchorFrame, "RIGHT", spacing, 0)
+	if iconOnLeft then
+		self.SecondaryCoinDisplay:SetPoint("LEFT", anchorFrame, "RIGHT", spacing, 0)
+	else
+		self.SecondaryCoinDisplay:SetPoint("RIGHT", anchorFrame, "LEFT", -spacing, 0)
+	end
 end
 
 function RLF_RowTextMixin:ShowItemCountText(itemCount, options)
@@ -1020,9 +1028,17 @@ function RLF_RowTextMixin:UpdateSecondaryCoinDisplay(gold, silver, copper, prefi
 		if onSecondaryRow then
 			-- Secondary row is active: re-layout the secondary line so SecondaryText
 			-- budget accounts for the coin display width, then anchor after it.
+			-- Anchor direction mirrors the text alignment: RIGHT-aligned feeds have
+			-- the icon on the right, so the coin display must sit to the LEFT of
+			-- SecondaryText rather than to its right (which would overlap the icon).
+			local iconOnLeft = self.cachedRowTextAlignment ~= G_RLF.TextAlignment.RIGHT
 			self:LayoutSecondaryLine()
 			local spacing = self.SecondaryLineLayout.spacing or 2
-			scd:SetPoint("LEFT", self.SecondaryText, "RIGHT", spacing, 0)
+			if iconOnLeft then
+				scd:SetPoint("LEFT", self.SecondaryText, "RIGHT", spacing, 0)
+			else
+				scd:SetPoint("RIGHT", self.SecondaryText, "LEFT", -spacing, 0)
+			end
 		else
 			-- Secondary row is not active: fall back to the primary line.
 			-- Re-layout the primary line so PrimaryText budget accounts for the coin

--- a/RPGLootFeed_spec/LootDisplay/LootDisplayFrame/LootDisplayRow/RowTextMixin_spec.lua
+++ b/RPGLootFeed_spec/LootDisplay/LootDisplayFrame/LootDisplayRow/RowTextMixin_spec.lua
@@ -9,6 +9,19 @@ local stub = busted.stub
 
 local MIXIN_FILE = "RPGLootFeed/LootDisplay/LootDisplayFrame/LootDisplayRow/RowTextMixin.lua"
 
+--- Stub a list of method names onto `tbl` using busted stubs.
+--- Mirrors the helper in LootDisplayRowFrame.lua so spec-local mocks
+--- can be built without importing the internal mock module directly.
+local function stubMethods(tbl, names)
+	for _, name in ipairs(names) do
+		if tbl[name] == nil then
+			tbl[name] = function() end
+		end
+		stub(tbl, name)
+	end
+	return tbl
+end
+
 describe("RLF_RowTextMixin", function()
 	local ns, row
 
@@ -645,6 +658,220 @@ describe("RLF_RowTextMixin", function()
 			-- follow-up SetPoint call on the result does not error.
 			RLF_RowTextMixin.CreateTopLeftText(row)
 			assert.stub(row.Icon.CreateFontString).was.called(1)
+		end)
+	end)
+
+	-- ── RecheckSecondaryCoinDisplayAnchor ──────────────────────────────────
+	-- Regression guard for issue #554: anchor must flip to RIGHT/LEFT when
+	-- the feed is right-aligned (icon on right) so the coin display appears to
+	-- the left of the text instead of overlapping the icon.
+
+	describe("RecheckSecondaryCoinDisplayAnchor", function()
+		local function makeScdMock()
+			local scd = {}
+			stubMethods(scd, { "ClearAllPoints", "SetPoint", "SetSize", "Show", "Hide" })
+			scd.IsShown = function()
+				return true
+			end
+			return scd
+		end
+
+		before_each(function()
+			row.PrimaryLineLayout.spacing = 8
+			row.SecondaryLineLayout.IsShown = function()
+				return false
+			end
+		end)
+
+		it("returns early without error when SecondaryCoinDisplay is absent", function()
+			row.SecondaryCoinDisplay = nil
+			RLF_RowTextMixin.RecheckSecondaryCoinDisplayAnchor(row)
+		end)
+
+		it("returns early when SecondaryCoinDisplay is hidden", function()
+			local scd = makeScdMock()
+			scd.IsShown = function()
+				return false
+			end
+			row.SecondaryCoinDisplay = scd
+			RLF_RowTextMixin.RecheckSecondaryCoinDisplayAnchor(row)
+			assert.stub(scd.SetPoint).was_not.called()
+		end)
+
+		it("returns early when SecondaryLineLayout is shown (SCD already on secondary row)", function()
+			row.SecondaryCoinDisplay = makeScdMock()
+			row.SecondaryLineLayout.IsShown = function()
+				return true
+			end
+			RLF_RowTextMixin.RecheckSecondaryCoinDisplayAnchor(row)
+			assert.stub(row.SecondaryCoinDisplay.SetPoint).was_not.called()
+		end)
+
+		describe("when left-aligned (icon on left)", function()
+			before_each(function()
+				row.cachedRowTextAlignment = "LEFT"
+				row.SecondaryCoinDisplay = makeScdMock()
+			end)
+
+			it("anchors SCD with LEFT/RIGHT points (after PrimaryText)", function()
+				local anchor, relPoint
+				stub(row.SecondaryCoinDisplay, "SetPoint", function(_, a, _, p)
+					anchor, relPoint = a, p
+				end)
+				RLF_RowTextMixin.RecheckSecondaryCoinDisplayAnchor(row)
+				assert.equal("LEFT", anchor)
+				assert.equal("RIGHT", relPoint)
+			end)
+
+			it("uses PrimaryText as the anchor frame when no count/amount/coin is shown", function()
+				local relFrame
+				stub(row.SecondaryCoinDisplay, "SetPoint", function(_, _, f)
+					relFrame = f
+				end)
+				RLF_RowTextMixin.RecheckSecondaryCoinDisplayAnchor(row)
+				assert.equal(row.PrimaryText, relFrame)
+			end)
+
+			it("uses ItemCountText as the anchor frame when ItemCountText is shown", function()
+				row.ItemCountText.IsShown = function()
+					return true
+				end
+				local relFrame
+				stub(row.SecondaryCoinDisplay, "SetPoint", function(_, _, f)
+					relFrame = f
+				end)
+				RLF_RowTextMixin.RecheckSecondaryCoinDisplayAnchor(row)
+				assert.equal(row.ItemCountText, relFrame)
+			end)
+		end)
+
+		describe("when right-aligned (icon on right) — issue #554 regression", function()
+			before_each(function()
+				row.cachedRowTextAlignment = "RIGHT"
+				row.SecondaryCoinDisplay = makeScdMock()
+			end)
+
+			it("anchors SCD with RIGHT/LEFT points (before PrimaryText, away from icon)", function()
+				local anchor, relPoint
+				stub(row.SecondaryCoinDisplay, "SetPoint", function(_, a, _, p)
+					anchor, relPoint = a, p
+				end)
+				RLF_RowTextMixin.RecheckSecondaryCoinDisplayAnchor(row)
+				assert.equal("RIGHT", anchor)
+				assert.equal("LEFT", relPoint)
+			end)
+
+			it("uses a negative x-offset so SCD clears the text to the left", function()
+				local xOff
+				stub(row.SecondaryCoinDisplay, "SetPoint", function(_, _, _, _, x)
+					xOff = x
+				end)
+				RLF_RowTextMixin.RecheckSecondaryCoinDisplayAnchor(row)
+				assert.is_true(xOff < 0)
+			end)
+
+			it("uses PrimaryText as anchor frame when no count/amount/coin is shown", function()
+				local relFrame
+				stub(row.SecondaryCoinDisplay, "SetPoint", function(_, _, f)
+					relFrame = f
+				end)
+				RLF_RowTextMixin.RecheckSecondaryCoinDisplayAnchor(row)
+				assert.equal(row.PrimaryText, relFrame)
+			end)
+		end)
+	end)
+
+	-- ── UpdateSecondaryCoinDisplay — anchor direction ──────────────────────
+	-- Regression guard for issue #554: when the secondary row is active the
+	-- coin display must be anchored on the correct side of SecondaryText.
+
+	describe("UpdateSecondaryCoinDisplay anchor direction (secondary row active)", function()
+		-- Build a minimal SecondaryCoinDisplay mock with denomination groups so
+		-- UpdateSecondaryCoinDisplay can run to completion and reach the anchor code.
+		local function makeDenomGroup()
+			local group = stubMethods({}, { "SetSize", "SetPoint", "ClearAllPoints", "Show", "Hide" })
+			group.amountText = stubMethods({}, {
+				"SetText",
+				"SetPoint",
+				"ClearAllPoints",
+				"SetFont",
+				"SetFontObject",
+				"SetTextColor",
+				"SetWordWrap",
+			})
+			group.amountText.GetUnboundedStringWidth = function()
+				return 20
+			end
+			group.icon = stubMethods({}, { "SetSize", "SetPoint", "ClearAllPoints", "Show", "Hide", "SetAtlas" })
+			return group
+		end
+
+		local function makeFullScdMock()
+			local scd = stubMethods({}, { "SetSize", "SetPoint", "ClearAllPoints", "Show", "Hide" })
+			scd.prefixIcon = stubMethods({}, {
+				"SetAtlas",
+				"SetSize",
+				"SetPoint",
+				"ClearAllPoints",
+				"Show",
+				"Hide",
+			})
+			scd.goldGroup = makeDenomGroup()
+			scd.silverGroup = makeDenomGroup()
+			scd.copperGroup = makeDenomGroup()
+			return scd
+		end
+
+		before_each(function()
+			-- Pre-set SCD so CreateSecondaryCoinDisplay is not called.
+			row.SecondaryCoinDisplay = makeFullScdMock()
+			-- Activate secondary row (so the onSecondaryRow branch is taken).
+			row.SecondaryLineLayout.IsShown = function()
+				return true
+			end
+			row.SecondaryLineLayout.spacing = 8
+			row.cachedSecondaryFontSize = 12
+			-- Stub layout helpers — tested separately.
+			stub(row, "LayoutSecondaryLine")
+			stub(row, "LayoutPrimaryLine")
+			stub(row, "RecheckSecondaryCoinDisplayAnchor")
+			stub(row, "StyleSecondaryCoinDisplay")
+		end)
+
+		it("anchors SCD with LEFT/RIGHT when left-aligned (icon on left)", function()
+			row.cachedRowTextAlignment = "LEFT"
+			local anchor, relPoint
+			stub(row.SecondaryCoinDisplay, "SetPoint", function(_, a, _, p)
+				anchor, relPoint = a, p
+			end)
+			-- Pass 5g so totalWidth > 0 and we reach the anchor code.
+			RLF_RowTextMixin.UpdateSecondaryCoinDisplay(row, 5, 0, 0)
+			assert.equal("LEFT", anchor)
+			assert.equal("RIGHT", relPoint)
+		end)
+
+		it("anchors SCD with RIGHT/LEFT when right-aligned — issue #554 regression", function()
+			row.cachedRowTextAlignment = "RIGHT"
+			local anchor, relPoint
+			stub(row.SecondaryCoinDisplay, "SetPoint", function(_, a, _, p)
+				anchor, relPoint = a, p
+			end)
+			RLF_RowTextMixin.UpdateSecondaryCoinDisplay(row, 5, 0, 0)
+			assert.equal("RIGHT", anchor)
+			assert.equal("LEFT", relPoint)
+		end)
+
+		it("uses SecondaryText as the relative frame for both alignments", function()
+			for _, alignment in ipairs({ "LEFT", "RIGHT" }) do
+				row.cachedRowTextAlignment = alignment
+				row.SecondaryCoinDisplay = makeFullScdMock()
+				local relFrame
+				stub(row.SecondaryCoinDisplay, "SetPoint", function(_, _, f)
+					relFrame = f
+				end)
+				RLF_RowTextMixin.UpdateSecondaryCoinDisplay(row, 5, 0, 0)
+				assert.equal(row.SecondaryText, relFrame, "alignment=" .. alignment)
+			end
 		end)
 	end)
 end)


### PR DESCRIPTION
## Description

Right-aligned loot feed frames had incorrect secondary row text positioning causing overlap.

## Related Issue

Closes #554 

## Screenshots, Videos, or GIFs

<img width="404" height="52" alt="image" src="https://github.com/user-attachments/assets/62b5372f-895b-457c-8a2e-bcb26beb7d82" />
